### PR TITLE
Fixes #12 Adds susi's capabilities to a telegram service account

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ var bodyParser = require('body-parser');
 var request = require('request');
 var app = express();
 
+var TelegramBot = require('node-telegram-bot-api');
+
 app.set('port', (process.env.PORT || 5000));
 
 app.use(bodyParser.urlencoded({extended: false}));
@@ -14,7 +16,13 @@ app.use(bodyParser.json());
 
 // recommended to inject access tokens as environmental variables, e.g.
 var token = process.env.FB_PAGE_ACCESS_TOKEN;
+var telegramToken = process.env.TELEGRAM_ACCESS_TOKEN;
+// Setup polling way
+var bot = new TelegramBot(telegramToken, {polling: true});
 // const token = "<PAGE_ACCESS_TOKEN>"
+
+// FACEBOOK SERVICE FOR SUSI
+// ----------------------------------------------------------------------------------------------------------------
 
 function sendTextMessage(sender, text) {
 	var messageData = { text:text };
@@ -37,7 +45,7 @@ function sendTextMessage(sender, text) {
 }
 
 function sendGenericMessage(sender, title, subtitle, image_url) {
-	let messageData = {
+	var messageData = {
 		"attachment": {
 			"type": "template",
 			"payload": {
@@ -121,6 +129,40 @@ app.post('/webhook/', function (req, res) {
 	}
 	res.sendStatus(200)
 })
+
+
+// TELEGRAM SERVICE FOR SUSI
+// ----------------------------------------------------------------------------------------------------------------
+// Matches /start 
+bot.onText(/\/start/, function (msg, match) {
+  var fromId = msg.from.id;
+  var resp = 'Hi, I am Susi, You can ask me anything !';
+  bot.sendMessage(fromId, resp);
+});
+
+// Any other message
+bot.on('message', function (msg) {
+	var chatId = msg.chat.id;
+	var queryUrl = 'http://loklak.org/api/susi.json?q='+encodeURI(msg.text);
+	var message = '';
+	// Wait until done and reply
+	if (msg.text !== '/start') {
+		request({
+			url: queryUrl,
+			json: true
+		}, function (error, response, body) {
+			if (!error && response.statusCode === 200) {
+				message = body.answers[0].actions[0].expression;
+				bot.sendMessage(chatId, message);
+			} else {
+				message = 'Oops, Looks like Susi is taking a break, She will be back soon';
+				bot.sendMessage(chatId, message);
+			}
+		});
+	}
+});
+
+// ----------------------------------------------------------------------------------------------------------------
 
 // Getting Susi up and running.
 app.listen(app.get('port'), function() {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "body-parser": "^1.15.0",
     "express": "^4.13.4",
+    "node-telegram-bot-api": "^0.23.3",
     "request": "^2.71.0",
     "requestify": "^0.1.17"
   }


### PR DESCRIPTION
- Telegram Live test URL: https://web.telegram.org/#/im?p=@asksusi_bot
- Starts default with `/start` when you start the interaction with Susi on Telegram
- Hosted on the same service endpoint URLs as that of Facebook Messenger Integration

<img width="696" alt="screen shot 2016-08-08 at 7 07 41 pm" src="https://cloud.githubusercontent.com/assets/4545925/17481559/70ea33ae-5d9b-11e6-9bc6-25d9818717b8.png">
